### PR TITLE
Fix argument `--no-yarn`

### DIFF
--- a/lib/update-dep.js
+++ b/lib/update-dep.js
@@ -33,7 +33,7 @@ async function yarnUpdateDependency() {
     .option('-ny, --no-yarn', 'Do not auto-run "yarn install"')
     .parse(process.argv);
 
-  let { targetVersion, package, caret, exact, noYarn } = program;
+  let { targetVersion, package, caret, exact, yarn: noYarn } = program;
 
   package = package || posPackage;
   let version = targetVersion || posVersion;


### PR DESCRIPTION
commander's argument parsing must have changed slightly, the option for `--no-yarn` comes through as `yarn` rather than `noYarn`