### PR TITLE
Drop `--caret`/`--tilde`/`--exact` options and keep current instead

### DIFF
--- a/lib/update-dep.js
+++ b/lib/update-dep.js
@@ -24,54 +24,63 @@ async function yarnUpdateDependency() {
     })
     .option('-v, --target-version <value>', 'The version to update to')
     .option('-p, --package <value>', 'The package to update')
-    .option('-c, --caret', 'Update the version to ^X.X.X')
-    .option('-t, --tilde', 'Update the version to ~X.X.X')
-    .option('-e, --exact', 'Update the version to X.X.X')
     .option('-ny, --no-yarn', 'Do not auto-run "yarn install"')
     .parse(process.argv);
 
-  let { targetVersion, package, caret, exact, yarn: runYarn } = program.opts();
+  let { targetVersion, package, yarn: runYarn } = program.opts();
 
   package = package || posPackage;
   let version = targetVersion || posVersion;
 
+  if (!package) {
+    throw new Error('You have to specify a package.');
+  }
+
+  await updateDependency(package, version);
+
+  if (!runYarn) {
+    log('');
+    log(chalk.green('Done! Please run `yarn` to update your dependencies.'));
+    return;
+  }
+
+  log('');
+  log('Now running `yarn` to install new dependency...');
+
+  await exec('yarn install');
+
+  log('');
+  log(chalk.green('Done!'));
+}
+
+function updateVersion(deps, package, version) {
+  // If not specifying a full version with ~ or ^, we want to keep the current symbol
+  if (!version.startsWith('~') && !version.startsWith('^')) {
+    let currentVersion = deps[package];
+    let currentSymbol = currentVersion[0];
+
+    if (currentSymbol === '~' || currentSymbol === '^') {
+      version = `${currentSymbol}${version}`;
+    }
+  }
+
+  deps[package] = version;
+}
+
+async function updateDependency(package, version) {
   if (typeof version === 'undefined') {
     let out = await exec(`npm show ${package} version`);
     version = out.stdout.trim();
     log(`Fetching latest version: ${version}`);
   }
 
-  if (!version.startsWith('~') && !version.startsWith('^')) {
-    let versionRangeChar = '~';
-    if (exact) {
-      versionRangeChar = '';
-    } else if (caret) {
-      versionRangeChar = '^';
-    }
-
-    version = `${versionRangeChar}${version}`;
-  }
-
-  if (!package || !version) {
-    throw new Error(
-      'You have to specify a package & version to update, e.g. "yu my-package 0.2.0"'
-    );
+  if (!version) {
+    throw new Error(`No version found to update to for package ${package}`);
   }
 
   log(`Updating ${package} to version ${version}...`);
 
-  let packageJson = readPackageJson('package.json');
-  let isWorkspace = !!packageJson.workspaces;
-
-  let packageJsonFilePaths = ['package.json'];
-  if (isWorkspace) {
-    packageJson.workspaces.forEach((workspacePattern) => {
-      let pattern = `${workspacePattern}/package.json`;
-      let workspacePackageJsonFiles = glob.sync(pattern);
-      packageJsonFilePaths.push(...workspacePackageJsonFiles);
-    });
-  }
-
+  let packageJsonFilePaths = getPackageJsonFiles();
   let hasAnyChange = false;
 
   // Update package.json files...
@@ -85,17 +94,17 @@ async function yarnUpdateDependency() {
     let hasChanged = false;
 
     if (dependencies[package]) {
-      dependencies[package] = version;
+      updateVersion(dependencies, package, version);
       hasChanged = true;
     }
 
     if (devDependencies[package]) {
-      devDependencies[package] = version;
+      updateVersion(devDependencies, package, version);
       hasChanged = true;
     }
 
     if (peerDependencies[package]) {
-      peerDependencies[package] = version;
+      updateVersion(peerDependencies, package, version);
       hasChanged = true;
     }
 
@@ -138,20 +147,6 @@ async function yarnUpdateDependency() {
     );
     return;
   }
-
-  if (!runYarn) {
-    log('');
-    log(chalk.green('Done! Please run `yarn` to update your dependencies.'));
-    return;
-  }
-
-  log('');
-  log('Now running `yarn` to install new dependency...');
-
-  await exec('yarn install');
-
-  log('');
-  log(chalk.green('Done!'));
 }
 
 module.exports = async function () {
@@ -165,4 +160,20 @@ module.exports = async function () {
 function log(str) {
   // eslint-disable-next-line no-console
   console.log(str);
+}
+
+function getPackageJsonFiles() {
+  let packageJson = readPackageJson('package.json');
+  let isWorkspace = !!packageJson.workspaces;
+
+  let packageJsonFilePaths = ['package.json'];
+  if (isWorkspace) {
+    packageJson.workspaces.forEach((workspacePattern) => {
+      let pattern = `${workspacePattern}/package.json`;
+      let workspacePackageJsonFiles = glob.sync(pattern);
+      packageJsonFilePaths.push(...workspacePackageJsonFiles);
+    });
+  }
+
+  return packageJsonFilePaths;
 }


### PR DESCRIPTION
This means, if you currently have a dependency in your package.json like this:

```
"my-dep": "~1.1.0"
// becomes...
"my-dep": "~1.3.0"

"other-dep": "^1.1.0"
// becomes...
"other-dep": "^1.3.0"
```

You can stil provide an exact version (like `yu my-dep "^1.3.0"`).