### PR TITLE
Restructure files to allow programmatic usage

### DIFF
--- a/bin/yarn-update
+++ b/bin/yarn-update
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../lib/update-dep')();
+require('../lib/index')();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,54 @@
+const chalk = require('chalk');
+const program = require('commander');
+const { version: packageVersion } = require('./../package');
+const yarnUpdateDependency = require('./update-dependency');
+
+async function run() {
+  let posPackage, posVersion;
+
+  program
+    .version(packageVersion, '--version')
+    .usage('[package] [version] [options]')
+    .arguments('[package] [version]')
+    .action(function (package, version) {
+      posPackage = package;
+      posVersion = version;
+    })
+    .option('-v, --target-version <value>', 'The version to update to')
+    .option('-p, --package <value>', 'The package to update')
+    .option('-ny, --no-yarn', 'Do not auto-run "yarn install"')
+    .option('-ad, --all-dependencies', 'Update all dependencies')
+    .option('-adev, --all-dev-dependencies', 'Update all devDependencies')
+    .option('-sm --silent', 'Silent output')
+    .parse(process.argv);
+
+  let {
+    targetVersion,
+    package,
+    yarn: runYarn,
+    allDependencies,
+    allDevDependencies,
+    silent = false,
+  } = program.opts();
+
+  package = package || posPackage;
+  let version = targetVersion || posVersion;
+
+  await yarnUpdateDependency({
+    version,
+    package,
+    yarn: runYarn,
+    allDependencies,
+    allDevDependencies,
+    silent,
+  });
+}
+
+module.exports = async function () {
+  try {
+    await run();
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(chalk.red(error));
+  }
+};

--- a/lib/update-dependency.js
+++ b/lib/update-dependency.js
@@ -4,57 +4,36 @@ const chalk = require('chalk');
 const lockfile = require('@yarnpkg/lockfile');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
-const program = require('commander');
-const { version: packageVersion } = require('./../package');
 
 function readPackageJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 }
 
-async function yarnUpdateDependency() {
-  let posPackage, posVersion;
-
-  program
-    .version(packageVersion, '--version')
-    .usage('[package] [version] [options]')
-    .arguments('[package] [version]')
-    .action(function (package, version) {
-      posPackage = package;
-      posVersion = version;
-    })
-    .option('-v, --target-version <value>', 'The version to update to')
-    .option('-p, --package <value>', 'The package to update')
-    .option('-ny, --no-yarn', 'Do not auto-run "yarn install"')
-    .option('-ad, --all-dependencies', 'Update all dependencies')
-    .option('-adev, --all-dev-dependencies', 'Update all devDependencies')
-    .parse(process.argv);
-
-  let {
-    targetVersion,
-    package,
-    yarn: runYarn,
-    allDependencies,
-    allDevDependencies,
-  } = program.opts();
-
-  package = package || posPackage;
-  let version = targetVersion || posVersion;
-
+async function yarnUpdateDependency({
+  version,
+  package,
+  yarn: runYarn,
+  allDependencies,
+  allDevDependencies,
+  silent = false,
+}) {
   if (!package && !allDependencies && !allDevDependencies) {
     throw new Error(
       'You have to specify a package, --all-dependencies or --all-dev-dependencies'
     );
   }
 
+  let logger = new Logger({ silent });
+
   if (package) {
-    await updateDependency(package, version);
+    await updateDependency(package, version, logger);
   }
 
   if (allDependencies) {
     let packages = getDependencies();
     for (let package of packages) {
-      log('');
-      log(`Trying to update ${package}...`);
+      logger.log('');
+      logger.log(`Trying to update ${package}...`);
       await updateDependency(package, version, {});
     }
   }
@@ -62,25 +41,27 @@ async function yarnUpdateDependency() {
   if (allDevDependencies) {
     let packages = getDevDependencies();
     for (let package of packages) {
-      log('');
-      log(`Trying to update ${package}...`);
+      logger.log('');
+      logger.log(`Trying to update ${package}...`);
       await updateDependency(package, version, {});
     }
   }
 
   if (!runYarn) {
-    log('');
-    log(chalk.green('Done! Please run `yarn` to update your dependencies.'));
+    logger.log('');
+    logger.log(
+      chalk.green('Done! Please run `yarn` to update your dependencies.')
+    );
     return;
   }
 
-  log('');
-  log('Now running `yarn` to install new dependency...');
+  logger.log('');
+  logger.log('Now running `yarn` to install new dependency...');
 
   await exec('yarn install');
 
-  log('');
-  log(chalk.green('Done!'));
+  logger.log('');
+  logger.log(chalk.green('Done!'));
 }
 
 function getDependencies() {
@@ -129,18 +110,18 @@ function updateVersion(deps, package, version) {
   deps[package] = version;
 }
 
-async function updateDependency(package, version) {
+async function updateDependency(package, version, logger) {
   if (typeof version === 'undefined') {
     let out = await exec(`npm show ${package} version`);
     version = out.stdout.trim();
-    log(`Fetching latest version: ${version}`);
+    logger.log(`Fetching latest version: ${version}`);
   }
 
   if (!version) {
     throw new Error(`No version found to update to for package ${package}`);
   }
 
-  log(`Updating ${package} to version ${version}...`);
+  logger.log(`Updating ${package} to version ${version}...`);
 
   let packageJsonFilePaths = getPackageJsonFiles();
   let hasAnyChange = false;
@@ -173,7 +154,7 @@ async function updateDependency(package, version) {
     if (hasChanged) {
       let fileContent = JSON.stringify(packageJsonFile, null, 2);
       fs.writeFileSync(filePath, fileContent, 'utf-8');
-      log(chalk.green(`✔ Updated version in ${filePath}`));
+      logger.log(chalk.green(`✔ Updated version in ${filePath}`));
       hasAnyChange = true;
     }
   });
@@ -191,7 +172,9 @@ async function updateDependency(package, version) {
   Object.keys(yarnLockEntries).forEach((lockedPackage) => {
     if (lockedPackage.startsWith(findKey)) {
       delete yarnLockEntries[lockedPackage];
-      log(chalk.green(`✔ Removed entry ${lockedPackage} from yarn.lock`));
+      logger.log(
+        chalk.green(`✔ Removed entry ${lockedPackage} from yarn.lock`)
+      );
       hasAnyChange = true;
     }
   });
@@ -201,8 +184,8 @@ async function updateDependency(package, version) {
 
   // Run `yarn`
   if (!hasAnyChange) {
-    log('');
-    log(
+    logger.log('');
+    logger.log(
       chalk.yellow(
         'No update occurred - the specified dependency could not be found.'
       )
@@ -211,17 +194,21 @@ async function updateDependency(package, version) {
   }
 }
 
-module.exports = async function () {
-  try {
-    await yarnUpdateDependency();
-  } catch (error) {
-    log(chalk.red(error));
-  }
-};
+module.exports = yarnUpdateDependency;
 
-function log(str) {
-  // eslint-disable-next-line no-console
-  console.log(str);
+class Logger {
+  constructor({ silent }) {
+    this.silent = silent;
+  }
+
+  log(str) {
+    if (this.silent) {
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(str);
+  }
 }
 
 function getPackageJsonFiles() {


### PR DESCRIPTION
You can use it like this:

```js
import yarnUpdateDependency from "yarn-update-dependency/lib/update-dep.js";

await yarnUpdateDependency({
  version: '1.0.0',
  package: 'my-package'
});
```

Normal usage should remain the same.
Note: This also adds a `--silent` option, which hides any non-error logs.